### PR TITLE
Add `gitignore` and ignore `.DS_Store`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Adds a `.gitignore` file to exclude macOS-specific `.DS_Store` files, which store `Finder` settings and are not relevant to the project.