### PR TITLE
Generar tráfico con INT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/traffic-generator/README.md
+++ b/traffic-generator/README.md
@@ -1,0 +1,16 @@
+## Requisitos
+- Python3
+- scapy
+
+## Instalacion en mac
+```
+brew install python@3.13
+python3 -m venv venv
+source venv/bin/activate
+pip install scapy
+```
+
+Cada vez que se quiera ejecutar se debe activar el `venv`
+```
+source venv/bin/activate
+```

--- a/traffic-generator/README.md
+++ b/traffic-generator/README.md
@@ -2,7 +2,7 @@
 - Python3
 - scapy
 
-## Instalacion en mac
+## Instalación en mac
 ```
 brew install python@3.13
 python3 -m venv venv

--- a/traffic-generator/base_traffic_generator.py
+++ b/traffic-generator/base_traffic_generator.py
@@ -19,13 +19,13 @@ INT_TYPE = 1              # 1 = INT-MD
 NPT_L4 = 2                # indicates that another (the original) L4 header follows the INT stack
 HOP_METADATA_LEN = 2      # 2 * 4B = 8 bytes per hop
 REMAINING_HOPS = 1
-INSTRUCTION_BITMAP = 0b11000000000000000000000000000000  # Node ID + Hop Latency (bit 0 + bit 2)
+INSTRUCTION_BITMAP = 0b00000000000000000000000000000101  # Node ID + Hop Latency (bit 0 + bit 2)
 
 
 def build_int_shim():
     # Type(4b)=1, NPT(2b)=2, Reserved(2b)=0 => 0b0001_10_00 = 0x18
     shim_type = (INT_TYPE << 4) | (NPT_L4 << 2)
-    shim_len = 7  # (INT-MD header + 3 hops * 8 bytes) = 12 + 24 = 36B => 36/4 = 9
+    shim_len = 9  # (INT-MD header + 3 hops * 8 bytes) = 12 + 24 = 36B => 36/4 = 9
     shim_proto = ORIGINAL_PROTO
     return struct.pack("!BBH", shim_type, shim_len, shim_proto)
 
@@ -34,7 +34,7 @@ def build_int_md_header():
     reserved = 0x00
     hop_ml = HOP_METADATA_LEN
     rhc = REMAINING_HOPS
-    header_part1 = struct.pack("!BBBx", ver_d_e_m, hop_ml, rhc)
+    header_part1 = struct.pack("!BBBB", ver_d_e_m, reserved, hop_ml, rhc)
 
     instruction_bitmap = INSTRUCTION_BITMAP
     domain_id = 0x0000

--- a/traffic-generator/base_traffic_generator.py
+++ b/traffic-generator/base_traffic_generator.py
@@ -1,24 +1,82 @@
 from scapy.all import Ether, IP, TCP, UDP, Raw, wrpcap
 import random
+import struct
 
 # CONFIG
-OUTPUT_PCAP = "base_traffic.pcap"
-NUM_PACKETS = 1_000_000
+OUTPUT_PCAP = "int_r3_capture.pcap"
+NUM_PACKETS = 1_000
 PACKET_SIZE = 64  # bytes total
+
 SRC_IP = "10.0.0.1"
 DST_IP = "10.0.0.18"
 SRC_PORT = 5432
 DST_PORT = 80
 PAYLOAD = b"dummy_payload"
 
-def generate_packet(i):
-    pkt = IP(src=SRC_IP, dst=DST_IP) / TCP(sport=SRC_PORT, dport=DST_PORT, seq=i) / Raw(load=PAYLOAD)
+INT_UDP_DST_PORT = 5000  # arbitrary INT UDP port
+ORIGINAL_PROTO = 6        # TCP
+INT_TYPE = 1              # 1 = INT-MD
+NPT_L4 = 2                # indicates that another (the original) L4 header follows the INT stack
+HOP_METADATA_LEN = 2      # 2 * 4B = 8 bytes per hop
+REMAINING_HOPS = 1
+INSTRUCTION_BITMAP = 0b11000000000000000000000000000000  # Node ID + Hop Latency (bit 0 + bit 2)
+
+
+def build_int_shim():
+    # Type(4b)=1, NPT(2b)=2, Reserved(2b)=0 => 0b0001_10_00 = 0x18
+    shim_type = (INT_TYPE << 4) | (NPT_L4 << 2)
+    shim_len = 7  # (INT-MD header + 3 hops * 8 bytes) = 12 + 24 = 36B => 36/4 = 9
+    shim_proto = ORIGINAL_PROTO
+    return struct.pack("!BBH", shim_type, shim_len, shim_proto)
+
+def build_int_md_header():
+    ver_d_e_m = 0x20  # version=2, D=0, E=0, M=0
+    reserved = 0x00
+    hop_ml = HOP_METADATA_LEN
+    rhc = REMAINING_HOPS
+    header_part1 = struct.pack("!BBBx", ver_d_e_m, hop_ml, rhc)
+
+    instruction_bitmap = INSTRUCTION_BITMAP
+    domain_id = 0x0000
+    part2 = struct.pack("!II", instruction_bitmap, domain_id)
+
+    ds_instruction = 0x00000000
+    return header_part1 + part2 + struct.pack("!I", ds_instruction)
+
+def build_metadata_stack():
+    hops = [
+        (0x03, 500),
+        (0x02, 300),
+        (0x01, 400),
+        ] # TODO: randomizar hop latency siguiendo determinada distribución
+    stack = b""
+    for node_id, latency in hops:
+        stack += struct.pack("!II", node_id, latency)
+    return stack
+
+def generate_int_packet(i):
+    ip = IP(src=SRC_IP, dst=DST_IP)
+
+    # Outer INT UDP encapsulation
+    int_udp = UDP(sport=random.randint(1024, 65535), dport=INT_UDP_DST_PORT)
+
+    # INT headers
+    shim = build_int_shim()
+    md_header = build_int_md_header()
+    metadata = build_metadata_stack()
+
+    # Original TCP + Payload
+    tcp = TCP(sport=SRC_PORT, dport=DST_PORT, seq=i)
+    payload = Raw(PAYLOAD)
+
+    # Final composition
+    pkt = ip / int_udp / Raw(shim + md_header + metadata) / tcp / payload
     return pkt
 
 def main():
     packets = []
     for i in range(NUM_PACKETS):
-        pkt = generate_packet(i)
+        pkt = generate_int_packet(i)
         packets.append(pkt)
 
         # flush to disk every N packets to save memory

--- a/traffic-generator/base_traffic_generator.py
+++ b/traffic-generator/base_traffic_generator.py
@@ -1,0 +1,36 @@
+from scapy.all import Ether, IP, TCP, UDP, Raw, wrpcap
+import random
+
+# CONFIG
+OUTPUT_PCAP = "base_traffic.pcap"
+NUM_PACKETS = 1_000_000
+PACKET_SIZE = 64  # bytes total
+SRC_IP = "10.0.0.1"
+DST_IP = "10.0.0.18"
+SRC_PORT = 5432
+DST_PORT = 80
+PAYLOAD = b"dummy_payload"
+
+def generate_packet(i):
+    pkt = IP(src=SRC_IP, dst=DST_IP) / TCP(sport=SRC_PORT, dport=DST_PORT, seq=i) / Raw(load=PAYLOAD)
+    return pkt
+
+def main():
+    packets = []
+    for i in range(NUM_PACKETS):
+        pkt = generate_packet(i)
+        packets.append(pkt)
+
+        # flush to disk every N packets to save memory
+        if len(packets) >= 10000:
+            print(f"{len(packets)} packets")
+            wrpcap(OUTPUT_PCAP, packets, append=True)
+            packets.clear()
+
+    if packets:
+        wrpcap(OUTPUT_PCAP, packets, append=True)
+
+    print(f"Done! {NUM_PACKETS} packets written to {OUTPUT_PCAP}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Escenario
Asumiendo esta topología:

<img width="826" alt="image" src="https://github.com/user-attachments/assets/d57acf85-d45b-4d05-8d41-c4437de849eb" />

Donde:
- R1: INT source
- R2, R3: INT transit nodes
- R4 + Host M: INT Sink

## Objetivo
- Simular tráfico capturado en R3, justo antes de ser enviado al INT sink.
- Este tráfico tiene que tener la metadata INT agregada en R1, R2 y R3, junto con la data y metadata correspondiente al paquete original dirigido de Host A a Host B.
- De momento INT solo agrega `Node ID` y `Hop Latency`

## Referencia
https://p4.org/p4-spec/docs/INT_v2_1.pdf