### PR TITLE
Parsear INT metadata

### DIFF
--- a/sink/main.p4
+++ b/sink/main.p4
@@ -114,11 +114,11 @@ struct headers {
 
   int_header_t                int_header;
   intl4_shim_t                intl4_shim;
-  stack_element_t[11]          node1_metadata;
-  stack_element_t[11]          node2_metadata;
-  stack_element_t[11]          node3_metadata;
-  stack_element_t[11]          node4_metadata;
-  stack_element_t[11]          node5_metadata;
+  stack_element_t[12]          node1_metadata;
+  stack_element_t[12]          node2_metadata;
+  stack_element_t[12]          node3_metadata;
+  stack_element_t[12]          node4_metadata;
+  stack_element_t[12]          node5_metadata;
 }
 
 /*************************************************************************


### PR DESCRIPTION
This pull request refactors the `sink/main.p4` file to improve the parsing and handling of in-band network telemetry (INT) metadata. The changes enhance clarity, modularity, and adherence to the INT specification by restructuring the parser and updating metadata definitions. Key updates include renaming variables for consistency, introducing per-node metadata counters, and implementing a more modular state machine for parsing node metadata.

### Metadata Enhancements:
* Added `nodes_present` and per-node entry counters (`node1_entries` to `node5_entries`) to the `metadata` structure for better tracking of INT metadata processing.

### Variable Renaming for Clarity:
* Renamed `node_1` to `node1_metadata`, `node_2` to `node2_metadata`, and so on, in the `headers` structure to align with naming conventions and improve readability.
* Updated parser state names, e.g., `parse_int_hdr` to `parse_int_header`, for consistency with the INT specification.

### Parser Refactoring:
* Replaced the previous node parsing logic with a modular state machine for each node (`parse_node1_entry`, `parse_node2_entry`, etc.), ensuring better scalability and maintainability.

### Deparser Updates:
* Updated the `MyDeparser` control block to emit the renamed metadata headers (`node1_metadata`, `node2_metadata`, etc.) instead of the old `node_1`, `node_2`, etc.