### PR TITLE
Fix build: Stop applying ipv4 lpm

### DIFF
--- a/sink/main.p4
+++ b/sink/main.p4
@@ -600,8 +600,6 @@ control MyIngress(inout headers hdr,
       if (hdr.intl4_shim.isValid()) {
         save_in_hash();
       }
-
-      ipv4_lpm.apply();
     }
   }
 }


### PR DESCRIPTION
Fix:
```
main.p4(604): error: Could not find declaration for ipv4_lpm
      ipv4_lpm.apply();
      ^^^^^^^^
error: Error during P4 compilation
```