### PR TITLE
Fix: Parse bitmap assuming bit 0 is MSB

### DIFF
--- a/sink/main.p4
+++ b/sink/main.p4
@@ -412,15 +412,15 @@ control MyIngress(inout headers hdr,
   }
 
   action populate_requested_metadata() {
-    meta.bitmap.node_id = (bit<1>) hdr.int_header.instruction & 0x1;
-    meta.bitmap.level1_interfaces = (bit<1>) (hdr.int_header.instruction >> 1) & 0x1;
-    meta.bitmap.hop_latency = (bit<1>) (hdr.int_header.instruction >> 2) & 0x1;
-    meta.bitmap.queue_occupancy = (bit<1>) (hdr.int_header.instruction >> 3) & 0x1;
+    meta.bitmap.node_id = (bit<1>) (hdr.int_header.instruction >> 8) & 0x1;
+    meta.bitmap.level1_interfaces = (bit<1>) (hdr.int_header.instruction >> 7) & 0x1;
+    meta.bitmap.hop_latency = (bit<1>) (hdr.int_header.instruction >> 6) & 0x1;
+    meta.bitmap.queue_occupancy = (bit<1>) (hdr.int_header.instruction >> 5) & 0x1;
     meta.bitmap.ingress_timestamp = (bit<1>) (hdr.int_header.instruction >> 4) & 0x1;
-    meta.bitmap.egress_timestamp = (bit<1>) (hdr.int_header.instruction >> 5) & 0x1;
-    meta.bitmap.level2_interfaces = (bit<1>) (hdr.int_header.instruction >> 6) & 0x1;
-    meta.bitmap.egress_interface_tx = (bit<1>) (hdr.int_header.instruction >> 7) & 0x1;
-    meta.bitmap.buffer_occupancy = (bit<1>) (hdr.int_header.instruction >> 8) & 0x1;
+    meta.bitmap.egress_timestamp = (bit<1>) (hdr.int_header.instruction >> 3) & 0x1;
+    meta.bitmap.level2_interfaces = (bit<1>) (hdr.int_header.instruction >> 2) & 0x1;
+    meta.bitmap.egress_interface_tx = (bit<1>) (hdr.int_header.instruction >> 2) & 0x1;
+    meta.bitmap.buffer_occupancy = (bit<1>) hdr.int_header.instruction & 0x1;
   }
 
   action populate_node_id_metadata() {


### PR DESCRIPTION
According to spec bit 0 should be the MSB

<img width="1126" height="463" alt="image" src="https://github.com/user-attachments/assets/7a385134-2077-45b4-8975-a6bdf55b7f2d" />


Reference:
https://p4.org/p4-spec/docs/INT_v2_1.pdf