### PR TITLE
Configurar `Filebeat` para ver los logs de Netronome

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,31 @@
 - En Wireshark hacer "Reload Lua Plugins" (`Shift + Cmd + L` en mac)
 
 Hacer eso la primera vez y cuando hayan cambios en el dissector
+
+## Scripts para stack de Elastic + Filebeat
+
+Este proyecto incluye dos scripts para manejar la infraestructura de monitoreo:
+
+- `bin/ensure_stack`: chequea que **Elasticsearch**, **Kibana** y **Filebeat** estén corriendo en el host.  
+  Si alguno no está en ejecución, lo inicia automáticamente.
+- `bin/setup_filebeat`: configura Filebeat para que tracee los logs de **Netronome**.
+
+## Cómo acceder a Kibana
+
+Para visualizar Elasticsearch/Kibana, es necesario conectarse al host con un túnel SSH:
+
+```bash
+ssh -L 5601:localhost:5601 nombre.apellido@lulu.fing.edu.uy
+ssh -L 5601:localhost:5601 host@ip
+```
+
+Luego, abrir en el navegador el siguiente enlace:
+
+```
+http://localhost:5601
+```
+
+## ⚠️ Advertencia
+
+El host debe contar con **Elasticsearch**, **Kibana** y **Filebeat** instalados.  
+Estos pueden instalarse utilizando `apt-get` y siguiendo las instrucciones en sus sitios oficiales.

--- a/bin/ensure_stack
+++ b/bin/ensure_stack
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Units to manage (change if your names differ)
+UNITS=(elasticsearch kibana filebeat)
+
+SUDO="sudo"
+[[ $EUID -eq 0 ]] && SUDO=""
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--check | --ensure | --restart]
+
+  --check     Show status (active/enabled) and exit non-zero if any is not active
+  --ensure    Enable + start any service that isn't running (default)
+  --restart   Restart all services
+
+Examples:
+  $(basename "$0")              # ensure (enable+start) all
+  $(basename "$0") --check      # just print statuses
+  $(basename "$0") --restart    # restart all
+EOF
+}
+
+status_unit() {
+  local u="$1"
+  local active enabled
+  active="$($SUDO systemctl is-active "$u" 2>/dev/null || true)"
+  enabled="$($SUDO systemctl is-enabled "$u" 2>/dev/null || true)"
+  printf "%-14s active=%-10s enabled=%s\n" "$u" "${active:-unknown}" "${enabled:-unknown}"
+}
+
+ensure_unit() {
+  local u="$1"
+  echo "→ $u"
+  $SUDO systemctl is-enabled --quiet "$u" || $SUDO systemctl enable "$u" >/dev/null 2>&1 || true
+  if ! $SUDO systemctl is-active --quiet "$u"; then
+    echo "  starting…"
+    $SUDO systemctl start "$u" || true
+    sleep 1
+  fi
+  if $SUDO systemctl is-active --quiet "$u"; then
+    echo "  ✓ running"
+  else
+    echo "  ✗ failed to start — recent logs:" >&2
+    $SUDO journalctl -u "$u" -n 100 --no-pager || true
+    exit 1
+  fi
+}
+
+restart_unit() {
+  local u="$1"
+  echo "↻ restarting $u…"
+  $SUDO systemctl restart "$u" || true
+  $SUDO systemctl is-active --quiet "$u" && echo "  ✓ running" || {
+    echo "  ✗ not running — logs:" >&2
+    $SUDO journalctl -u "$u" -n 100 --no-pager || true
+    exit 1
+  }
+}
+
+mode="${1:---ensure}"
+case "$mode" in
+  --help|-h) usage; exit 0 ;;
+  --check|--ensure|--restart) ;;
+  *) usage; exit 2 ;;
+esac
+
+case "$mode" in
+  --check)
+    bad=0
+    for u in "${UNITS[@]}"; do
+      status_unit "$u"
+      $SUDO systemctl is-active --quiet "$u" || bad=1
+    done
+    exit "$bad"
+    ;;
+  --ensure)
+    for u in "${UNITS[@]}"; do
+      ensure_unit "$u"
+    done
+    echo "✅ all services active"
+    ;;
+  --restart)
+    for u in "${UNITS[@]}"; do
+      restart_unit "$u"
+    done
+    echo "✅ all services restarted"
+    ;;
+esac

--- a/bin/setup_filebeat
+++ b/bin/setup_filebeat
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ELASTIC_DIR="${ELASTIC_DIR:-$REPO_ROOT/elastic}"
+
+FB_SRC="${FB_SRC:-$ELASTIC_DIR/filebeat.yml}"
+FB_DST="${FB_DST:-/etc/filebeat/filebeat.yml}"
+
+PIPELINE_NAME="${PIPELINE_NAME:-nfp_logs_pipeline}"
+PIPELINE_FILE="${PIPELINE_FILE:-$ELASTIC_DIR/pipelines/nfp_logs_pipeline.json}"
+
+ES_URL="${ES_URL:-https://localhost:9200}"
+ES_USERNAME="${ES_USERNAME:-elastic}"
+ES_PASSWORD="${ES_PASSWORD:-}"
+ES_API_KEY="${ES_API_KEY:-}"                  # alternative to user/pass
+ES_CA_CERT="${ES_CA_CERT:-/etc/elasticsearch/certs/http_ca.crt}"
+ES_INSECURE="${ES_INSECURE:-false}"           # set true to skip TLS verify (dev)
+
+curl_es () {
+  local args=( -sS -H 'Content-Type: application/json' )
+  [[ -n "$ES_API_KEY" ]] && args+=( -H "Authorization: ApiKey $ES_API_KEY" )
+  [[ -z "$ES_API_KEY" ]] && args+=( -u "$ES_USERNAME:$ES_PASSWORD" )
+  [[ -n "$ES_CA_CERT" && "$ES_INSECURE" != "true" ]] && args+=( --cacert "$ES_CA_CERT" )
+  [[ "$ES_INSECURE" == "true" ]] && args+=( -k )
+  curl "${args[@]}" "$@"
+}
+
+echo "→ linking $FB_SRC → $FB_DST"
+sudo install -d -m 0755 /etc/filebeat
+if [[ -e "$FB_DST" && ! -L "$FB_DST" ]]; then
+  sudo cp -a "$FB_DST" "${FB_DST}.bak.$(date +%Y%m%d%H%M%S)"
+  echo "  backed up existing config to ${FB_DST}.bak.*"
+fi
+sudo ln -snf "$FB_SRC" "$FB_DST"
+sudo chown root:root "$FB_DST" || true
+sudo chmod 0644 "$FB_DST" || true
+
+echo "→ uploading ingest pipeline: $PIPELINE_NAME"
+curl_es -X PUT "$ES_URL/_ingest/pipeline/$PIPELINE_NAME" --data-binary "@${PIPELINE_FILE}"
+echo
+
+echo "→ filebeat test config"
+sudo filebeat test config
+
+echo "→ filebeat setup (templates/dashboards)"
+# use a temp data path to avoid the service lock
+sudo filebeat setup -E path.data="/tmp/fb-setup-$$" || true
+
+echo "→ restarting filebeat"
+sudo systemctl restart filebeat
+sudo systemctl is-active --quiet filebeat && echo "✓ filebeat running"
+
+echo "✅ setup complete"

--- a/elastic/filebeat.yml
+++ b/elastic/filebeat.yml
@@ -1,0 +1,22 @@
+filebeat.inputs:
+  - type: filestream
+    id: nfp-logs
+    enabled: true
+    paths:
+      - /var/log/nfp-hwdbg-srv.log
+      - /var/log/nfp-sdk6-rte.log
+      - /var/log/nfp-sdk6-rtelib.log
+
+    fields:
+      service: nfp
+      event.dataset: nfp.logs
+    fields_under_root: true
+
+output.elasticsearch:
+  hosts: ["https://localhost:9200"]
+  username: "${ES_USERNAME:elastic}"
+  password: "${ES_PASSWORD}"
+  ssl.certificate_authorities: ["/etc/elasticsearch/certs/http_ca.crt"]
+  pipeline: "nfp_logs_pipeline"
+
+setup.ilm.enabled: false

--- a/elastic/pipelines/nfp_logs_pipeline.json
+++ b/elastic/pipelines/nfp_logs_pipeline.json
@@ -1,0 +1,26 @@
+{
+  "description": "Parse Netronome NFP logs (HWD/RTE/PIFLIB)",
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": [
+          "^%{WORD:nfp.source}: %{TIMESTAMP_ISO8601:nfp.ts} - %{DATA:src.file}:%{NUMBER:src.line:int} %{GREEDYDATA:nfp.msg}"
+        ],
+        "ignore_failure": true
+      }
+    },
+    {
+      "date": {
+        "field": "nfp.ts",
+        "formats": ["yyyy-MM-dd HH:mm:ss:SSS"],
+        "ignore_failure": true
+      }
+    },
+    { "set": { "field": "event.module", "value": "nfp", "ignore_failure": true } },
+    { "rename": { "field": "nfp.msg", "target_field": "message", "ignore_missing": true, "ignore_failure": true } }
+  ],
+  "on_failure": [
+    { "set": { "field": "error.message", "value": "{{ _ingest.on_failure_message }}" } }
+  ]
+}


### PR DESCRIPTION
#### Qué?

Se agregan 2 scripts:
- **ensure_stack**: chequea que tanto Elastisearch, Kibana o Filebeat esten corriendo en el host, sino los ejecuta.
- **setup_fileabeat**: configura Filebeat para que traqueé los logs de Netronome.

#### Cómo ver Elastisearch?

Se debe conectar a la maquina utilizando:

```sh
ssh -L 5601:localhost:5601 nombre.apellido@lulu.fing.edu.uy
ssh -L 5601:localhost:5601 host@ip
```

Luego localmente se deberá acceder en el navegador al siguiente [link](http://localhost:5601/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-15m,to:now))&_a=(columns:!(),dataSource:(dataViewId:'filebeat-*',type:dataView),filters:!(),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))).

> [!warning]
> El host debe contar con Elasticsearch, Kibana y Filebeat instalados, estos pueden instalarse utilizando `apt-get` y siguiendo las instrucciones en sus sitios oficiales.