### PR TITLE
Vaciar buckets utilizando Spooler

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -3,7 +3,7 @@ CFLAGS   := -w -I/opt/netronome/include/
 LDFLAGS  := -L/opt/netronome/lib/
 LDLIBS   := -lnfp -lz -pthread
 
-SRC      := host_reader.c event_ring_worker.c
+SRC      := host_reader.c event_ring_worker.c spooler.c
 OBJ      := $(SRC:.c=.o)
 TARGET   := host_reader
 

--- a/host/host_reader.c
+++ b/host/host_reader.c
@@ -3,9 +3,9 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
-#include <zlib.h>
 #include <pthread.h>
 #include <getopt.h>
+#include <signal.h>
 
 #include "nfp.h"
 #include "nfp_cpp.h"
@@ -14,33 +14,32 @@
 
 #include "ring_defs.h"
 #include "event_ring_worker.h"
+#include "spooler.h"
 
 volatile int stop = 0;
 int debug = 0;
 
-void interrupt_handler(int dummy) {
+static void interrupt_handler(int dummy) {
     (void)dummy;
     stop = 1;
-}
-
-uint32_t hash_me_crc32(const uint32_t key[4]) {
-    uLong crc = crc32(0L, Z_NULL, 0);
-    crc = crc32(crc, (const Bytef *)key, 4*4);
-    return (uint32_t)(crc & (FLOWCACHE_ROWS - 1));
 }
 
 int main(int argc, char *argv[]) {
     int opt;
     while ((opt = getopt(argc, argv, "D")) != -1) {
         switch (opt) {
-            case 'D':
-                debug = 1;
-                break;
+            case 'D': debug = 1; break;
             default:
                 fprintf(stderr, "Usage: %s [-D]    Enable debug mode (shows detailed output)\n", argv[0]);
                 exit(EXIT_FAILURE);
         }
     }
+
+    signal(SIGINT, interrupt_handler);
+
+    /* ---- Spooler startup (queue + spool thread) ---- */
+    spooler_init();
+    spooler_start();
 
     struct nfp_device *h_nfp = NULL;
     struct nfp_cpp *h_cpp = NULL;
@@ -59,21 +58,14 @@ int main(int argc, char *argv[]) {
     memset(area_rings_I, 0, sizeof(area_rings_I));
     memset(area_ring_metas_I, 0, sizeof(area_ring_metas_I));
 
-    bucket_list *int_flowcache = malloc(FLOWCACHE_ROWS * sizeof(bucket_list));
-    memset(int_flowcache, 0, sizeof(int_flowcache));
-
-    uint32_t hash_key[4];
-    volatile uint32_t hash_value;
-
-    signal(SIGINT, interrupt_handler);
-
     int ret = 0;
 
     /* 1. Open NFP device and get CPP handle */
     h_nfp = nfp_device_open(0);
     if (!h_nfp) {
         fprintf(stderr, "Error: Failed to open NFP device (%s)\n", strerror(errno));
-        return 1;
+        ret = 1;
+        goto exit_spooler_stop;
     }
 
     h_cpp = nfp_device_cpp(h_nfp);
@@ -83,85 +75,47 @@ int main(int argc, char *argv[]) {
         goto exit_cleanup_nfp_device;
     }
 
-    /* 2. Look up the runtime symbol for ring_buffer_G and ring_buffer_I */
+    /* 2. Look up runtime symbols */
     rtsym_ring_buffer_G = nfp_rtsym_lookup(h_nfp, "_ring_buffer_G");
-    if (!rtsym_ring_buffer_G) {
-        fprintf(stderr, "Error: Could not find runtime symbol 'ring_buffer_G' (%s)\n", strerror(errno));
-        ret = 1;
-        goto exit_cleanup_nfp_device;
-    }
+    if (!rtsym_ring_buffer_G) { fprintf(stderr, "Error: Could not find 'ring_buffer_G' (%s)\n", strerror(errno)); ret = 1; goto exit_cleanup_nfp_device; }
 
     rtsym_ring_buffer_I = nfp_rtsym_lookup(h_nfp, "_ring_buffer_I");
-    if (!rtsym_ring_buffer_I) {
-        fprintf(stderr, "Error: Could not find runtime symbol 'ring_buffer_I' (%s)\n", strerror(errno));
-        ret = 1;
-        goto exit_cleanup_nfp_device;
-    }
+    if (!rtsym_ring_buffer_I) { fprintf(stderr, "Error: Could not find 'ring_buffer_I' (%s)\n", strerror(errno)); ret = 1; goto exit_cleanup_nfp_device; }
 
-    /* 2.5. Look up the runtime symbol for ring_G and ring_I */
     rtsym_ring_G = nfp_rtsym_lookup(h_nfp, "_ring_G");
-    if (!rtsym_ring_G) {
-        fprintf(stderr, "Error: Could not find runtime symbol 'ring_G' (%s)\n", strerror(errno));
-        ret = 1;
-        goto exit_cleanup_nfp_device;
-    }
+    if (!rtsym_ring_G) { fprintf(stderr, "Error: Could not find 'ring_G' (%s)\n", strerror(errno)); ret = 1; goto exit_cleanup_nfp_device; }
 
     rtsym_ring_I = nfp_rtsym_lookup(h_nfp, "_ring_I");
-    if (!rtsym_ring_I) {
-        fprintf(stderr, "Error: Could not find runtime symbol 'ring_I' (%s)\n", strerror(errno));
-        ret = 1;
-        goto exit_cleanup_nfp_device;
-    }
+    if (!rtsym_ring_I) { fprintf(stderr, "Error: Could not find 'ring_I' (%s)\n", strerror(errno)); ret = 1; goto exit_cleanup_nfp_device; }
 
-    /* 3. Allocate and acquire CPP areas for all rings and their metadata */
+    /* 3. Allocate CPP areas */
     for (int i = 0; i < NUM_RINGS; i++) {
-        /* General rings */
-        uint64_t offset_ring_buffer_target = rtsym_ring_buffer_G->addr + ((uint64_t)i * sizeof(ring_list));
-        uint32_t cpp_id_ring_buffer = NFP_CPP_ISLAND_ID(rtsym_ring_buffer_G->target, NFP_CPP_ACTION_RW, 0, rtsym_ring_buffer_G->domain);
+        /* G rings */
+        uint64_t off_rb_g  = rtsym_ring_buffer_G->addr + ((uint64_t)i * sizeof(ring_list));
+        uint32_t cpp_rb_g  = NFP_CPP_ISLAND_ID(rtsym_ring_buffer_G->target, NFP_CPP_ACTION_RW, 0, rtsym_ring_buffer_G->domain);
+        area_rings_G[i]    = nfp_cpp_area_alloc_acquire(h_cpp, cpp_rb_g, off_rb_g, sizeof(ring_list));
+        if (!area_rings_G[i]) { fprintf(stderr, "Error: CPP area for ring buffer G %d\n", i+1); ret = 1; goto exit_cleanup_areas; }
 
-        area_rings_G[i] = nfp_cpp_area_alloc_acquire(h_cpp, cpp_id_ring_buffer, offset_ring_buffer_target, sizeof(ring_list));
-        if (!area_rings_G[i]) {
-            fprintf(stderr, "Error: Failed to allocate and acquire CPP area for ring buffer G %d (%s)\n", i + 1, strerror(errno));
-            ret = 1;
-            goto exit_cleanup_areas;
-        }
+        /* I rings */
+        uint64_t off_rb_i  = rtsym_ring_buffer_I->addr + ((uint64_t)i * sizeof(event_ring_list));
+        uint32_t cpp_rb_i  = NFP_CPP_ISLAND_ID(rtsym_ring_buffer_I->target, NFP_CPP_ACTION_RW, 0, rtsym_ring_buffer_I->domain);
+        area_rings_I[i]    = nfp_cpp_area_alloc_acquire(h_cpp, cpp_rb_i, off_rb_i, sizeof(event_ring_list));
+        if (!area_rings_I[i]) { fprintf(stderr, "Error: CPP area for ring buffer I %d\n", i+1); ret = 1; goto exit_cleanup_areas; }
 
-        /* Event rings */
-        offset_ring_buffer_target = rtsym_ring_buffer_I->addr + ((uint64_t)i * sizeof(event_ring_list));
-        cpp_id_ring_buffer = NFP_CPP_ISLAND_ID(rtsym_ring_buffer_I->target, NFP_CPP_ACTION_RW, 0, rtsym_ring_buffer_I->domain);
+        /* G ring metas */
+        uint64_t off_meta_g = rtsym_ring_G->addr + ((uint64_t)i * sizeof(ring_meta));
+        uint32_t cpp_meta_g = NFP_CPP_ISLAND_ID(rtsym_ring_G->target, NFP_CPP_ACTION_RW, 0, rtsym_ring_G->domain);
+        area_ring_metas_G[i]= nfp_cpp_area_alloc_acquire(h_cpp, cpp_meta_g, off_meta_g, sizeof(ring_meta));
+        if (!area_ring_metas_G[i]) { fprintf(stderr, "Error: CPP area for ring meta G %d\n", i+1); ret = 1; goto exit_cleanup_areas; }
 
-        area_rings_I[i] = nfp_cpp_area_alloc_acquire(h_cpp, cpp_id_ring_buffer, offset_ring_buffer_target, sizeof(event_ring_list));
-        if (!area_rings_I[i]) {
-            fprintf(stderr, "Error: Failed to allocate and acquire CPP area for ring buffer I %d (%s)\n", i + 1, strerror(errno));
-            ret = 1;
-            goto exit_cleanup_areas;
-        }
-
-        /*** Rings metadata ***/
-
-         /* General rings */
-        uint64_t offset_ring_meta_target = rtsym_ring_G->addr + ((uint64_t)i * sizeof(ring_meta));
-        uint32_t cpp_id_ring_meta = NFP_CPP_ISLAND_ID(rtsym_ring_G->target, NFP_CPP_ACTION_RW, 0, rtsym_ring_G->domain);
-
-        area_ring_metas_G[i] = nfp_cpp_area_alloc_acquire(h_cpp, cpp_id_ring_meta, offset_ring_meta_target, sizeof(ring_meta));
-        if (!area_ring_metas_G[i]) {
-            fprintf(stderr, "Error: Failed to allocate and acquire CPP area for ring meta G %d (%s)\n", i + 1, strerror(errno));
-            ret = 1;
-            goto exit_cleanup_areas;
-        }
-
-        /* Event rings*/
-        offset_ring_meta_target = rtsym_ring_I->addr + ((uint64_t)i * sizeof(event_ring_list));
-        cpp_id_ring_meta = NFP_CPP_ISLAND_ID(rtsym_ring_I->target, NFP_CPP_ACTION_RW, 0, rtsym_ring_I->domain);
-
-        area_ring_metas_I[i] = nfp_cpp_area_alloc_acquire(h_cpp, cpp_id_ring_meta, offset_ring_meta_target, sizeof(event_ring_list));
-        if (!area_ring_metas_I[i]) {
-            fprintf(stderr, "Error: Failed to allocate and acquire CPP area for ring meta I %d (%s)\n", i + 1, strerror(errno));
-            ret = 1;
-            goto exit_cleanup_areas;
-        }
+        /* I ring metas */
+        uint64_t off_meta_i = rtsym_ring_I->addr + ((uint64_t)i * sizeof(event_ring_list));
+        uint32_t cpp_meta_i = NFP_CPP_ISLAND_ID(rtsym_ring_I->target, NFP_CPP_ACTION_RW, 0, rtsym_ring_I->domain);
+        area_ring_metas_I[i]= nfp_cpp_area_alloc_acquire(h_cpp, cpp_meta_i, off_meta_i, sizeof(event_ring_list));
+        if (!area_ring_metas_I[i]) { fprintf(stderr, "Error: CPP area for ring meta I %d\n", i+1); ret = 1; goto exit_cleanup_areas; }
     }
 
+    /* 4. Start event-ring workers (I rings) */
     pthread_t threads_ring_I[NUM_RINGS];
     thread_arg_t args[NUM_RINGS];
     for (int i = 0; i < NUM_RINGS; i++) {
@@ -175,10 +129,10 @@ int main(int argc, char *argv[]) {
             goto exit_cleanup_areas;
         }
     }
-    /**************************************************************************************************************************/
 
+    /*********************** MAIN DRAIN LOOP *************************/
     printf("Starting to read all Ring buffers\n");
-    if (debug) printf("\n----Debug mode is active - detailed output enabled----\n\n");
+    if (debug) printf("\n---- Debug mode is active - detailed output enabled ----\n\n");
 
     unsigned long long loop_iteration = 0;
     while (!stop) {
@@ -189,74 +143,70 @@ int main(int argc, char *argv[]) {
             if (nfp_cpp_area_read(area_ring_metas_G[i], 0, &current_ring_meta, sizeof(ring_meta)) < 0) {
                 fprintf(stderr, "Error: Failed to read ring meta for ring %d in loop (%s)\n", i + 1, strerror(errno));
                 ret = 1;
-                goto exit_cleanup_areas;
+                goto exit_join_I_workers;
             }
 
             uint32_t wp = current_ring_meta.write_pointer;
             uint32_t rp = current_ring_meta.read_pointer;
             uint32_t full = current_ring_meta.full;
+
             if (debug) {
                 printf("Ring %d - WP: %u, RP: %u, Full: %u\n", i + 1, wp, rp, full);
             }
+
             int j = 0;
             for (j = 0; j < BATCH_SIZE; j++) {
-
-                /* Contrl if ring is empty */
-                if (rp == wp && !full) { break; }
+                /* ring empty? */
+                if (rp == wp && !full) break;
 
                 bucket_entry current_ring_entry;
                 uint64_t offset_bucket_entry = (uint64_t)rp * sizeof(bucket_entry);
                 if (nfp_cpp_area_read(area_rings_G[i], offset_bucket_entry, &current_ring_entry, sizeof(bucket_entry)) < 0) {
-                    fprintf(stderr, "Error: Failed to read bucket entry from ring buffer %d.\n",
-                            i + 1, offset_bucket_entry, strerror(errno));
+                    fprintf(stderr, "Error: Failed to read bucket entry from ring buffer %d.\n", i + 1);
                     ret = 1;
-                    goto exit_cleanup_areas;
+                    goto exit_join_I_workers;
                 }
 
-                hash_key[0] = current_ring_entry.key[0];
-                hash_key[1] = current_ring_entry.key[1];
-                hash_key[2] = current_ring_entry.key[2];
-                hash_key[3] = current_ring_entry.key[3];
-                hash_value = hash_me_crc32(hash_key);
+                if (!spooler_enqueue(&current_ring_entry)) {
+                    /* If stop is set while waiting, break gracefully */
+                    break;
+                }
 
                 if (debug) {
-                    printf("  Entry[%u] Key Flow: [%u, %u, %u, %u]\n", rp,
-                            current_ring_entry.key[0],
-                            current_ring_entry.key[1],
-                            current_ring_entry.key[2],
-                            current_ring_entry.key[3]);
+                    printf("  Entry[%u] Key Flow: [%u, %u, %u, %u]  packets=%u\n",
+                        rp,
+                        current_ring_entry.key[0],
+                        current_ring_entry.key[1],
+                        current_ring_entry.key[2],
+                        current_ring_entry.key[3],
+                        current_ring_entry.packet_count);
                 }
 
-                /* Linear probing */
-                int k = 0;
-                while (int_flowcache[hash_value + k].entry[0].packet_count != 0) {
-                    k++;
-                }
-                memcpy(&int_flowcache[hash_value + k].entry[0], &current_ring_entry, sizeof(bucket_entry));
-                if (debug) {
-                    printf("  Hop Latency: %u | Queue Occupancy: %u\n\n", 
-                            int_flowcache[hash_value + k].entry[0].int_metric_info_value.average[0].hop_latency,
-                            int_flowcache[hash_value + k].entry[0].int_metric_info_value.average[0].queue_occupancy);
-                }
                 rp = (rp + 1) & (RING_SIZE - 1);
-
-                if (debug) usleep(1000000); // Sleep for 1s
+                if (debug) usleep(1000); /* 1ms pacing in debug */
             }
+
+            /* Advance read pointer if we consumed anything */
             if (j > 0) {
-                if (full) { full = 0; }
+                if (full) full = 0;
                 current_ring_meta.read_pointer = rp;
                 current_ring_meta.full = full;
                 if (nfp_cpp_area_write(area_ring_metas_G[i], 0, &current_ring_meta, sizeof(ring_meta)) < 0) {
                     fprintf(stderr, "Error: Failed to write updated ring meta for ring %d (%s)\n", i + 1, strerror(errno));
                     ret = 1;
-                    goto exit_cleanup_areas;
+                    goto exit_join_I_workers;
                 }
             }
+
             if (debug) printf("  Processed %d entries from ring %d in iteration %llu\n\n", j, i + 1, loop_iteration);
         }
-        if (debug) usleep(3000000); // Sleep for 3s
-    }
 
+        if (debug) usleep(3000);
+        loop_iteration++;
+    }
+    /*****************************************************************/
+
+exit_join_I_workers:
     for (int i = 0; i < NUM_RINGS; i++) {
         pthread_join(threads_ring_I[i], NULL);
     }
@@ -264,10 +214,16 @@ int main(int argc, char *argv[]) {
 exit_cleanup_areas:
     for (int i = 0; i < NUM_RINGS; i++) {
         if (area_ring_metas_G[i]) { nfp_cpp_area_release_free(area_ring_metas_G[i]); }
-        if (area_rings_G[i]) { nfp_cpp_area_release_free(area_rings_G[i]); }
+        if (area_rings_G[i])      { nfp_cpp_area_release_free(area_rings_G[i]); }
+        if (area_ring_metas_I[i]) { nfp_cpp_area_release_free(area_ring_metas_I[i]); }
+        if (area_rings_I[i])      { nfp_cpp_area_release_free(area_rings_I[i]); }
     }
 
 exit_cleanup_nfp_device:
     if (h_nfp) { nfp_device_close(h_nfp); }
+
+exit_spooler_stop:
+    spooler_stop();
+
     return ret;
 }

--- a/host/spooler.c
+++ b/host/spooler.c
@@ -1,0 +1,266 @@
+// spooler.c
+//
+// Spooler = lock-free-ish producer/consumer with a bounded queue.
+// Producers (your ring readers) call spooler_enqueue(bucket_entry*).
+// A single background thread pops entries and appends them as **one JSON
+// document per line** into a rolling ".ndjson.open" file, which is atomically
+// renamed to ".ndjson" on rotation/close. Filebeat tails only the closed files.
+//
+// Each document includes:
+//   - @timestamp                : host wall-clock (ISO8601, UTC)
+//   - host.name                 : hostname
+//   - flow.id / flow.key[]     : 4x u32 key (hex id + numeric array)
+//   - network.packets          : packet_count
+//   - int_ts_raw               : NIC raw timestamp (ns)
+//   - int.node_count           : # INT nodes
+//   - int.latest[] / average[] : arrays of {node_id, hop_latency, queue_occupancy, egress_interface_tx}
+//
+// Notes:
+//   - No Bulk action lines; NDJSON is compatible with Filebeat filestream+ndjson parser.
+//   - SEG_MAX_AGE_MS defaults to 10s to avoid sub-1KB segments at low traffic.
+//   - On shutdown, we drain the queue before closing/renaming the final segment.
+
+#include "spooler.h"
+#include "ring_defs.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>     // gethostname, fsync
+#include <time.h>       // clock_gettime, gmtime_r
+#include <sys/stat.h>   // mkdir, stat
+#include <limits.h>
+
+#define SPOOL_DIR         "/var/spool/int"
+#define SEG_MAX_BYTES     (128u * 1024u * 1024u) /* 128 MB */
+#define SEG_MAX_DOCS      500000u
+#define SEG_MAX_AGE_MS    10000u                  /* 10s: avoids tiny segments */
+#define HOSTNAME_MAX_LEN  128
+
+extern volatile int stop;
+
+/* ---------------- Queue ---------------- */
+typedef struct {
+    bucket_entry *buf;
+    size_t cap, head, tail, size;
+    pthread_mutex_t mu;
+    pthread_cond_t  not_empty, not_full;
+} bucket_queue;
+
+static bucket_queue g_q;
+
+/* ---------------- Spooler ---------------- */
+typedef struct {
+    FILE  *fp;
+    char   path_open[PATH_MAX];
+    char   path_ready[PATH_MAX];
+    size_t bytes;
+    size_t docs;
+    uint64_t opened_ms;
+    char hostname[HOSTNAME_MAX_LEN];
+    uint64_t seq;
+} spooler_t;
+
+static spooler_t g_spooler;
+static pthread_t g_thread;
+
+/* ---------------- Helpers ---------------- */
+static inline uint64_t now_ms(void) {
+    struct timespec ts; clock_gettime(CLOCK_REALTIME, &ts);
+    return (uint64_t)ts.tv_sec * 1000ull + (uint64_t)ts.tv_nsec / 1000000ull;
+}
+
+static void now_iso8601(char *out, size_t outlen) {
+    struct timespec ts; clock_gettime(CLOCK_REALTIME, &ts);
+    time_t secs = ts.tv_sec; struct tm tm; gmtime_r(&secs, &tm);
+    int ms = (int)(ts.tv_nsec / 1000000);
+    snprintf(out, outlen, "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
+             tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+             tm.tm_hour, tm.tm_min, tm.tm_sec, ms);
+}
+
+static void q_init(bucket_queue *q, size_t cap) {
+    q->buf = (bucket_entry*)calloc(cap, sizeof(bucket_entry));
+    if (!q->buf) { perror("calloc queue"); exit(1); }
+    q->cap = cap; q->head = q->tail = q->size = 0;
+    pthread_mutex_init(&q->mu, NULL);
+    pthread_cond_init(&q->not_empty, NULL);
+    pthread_cond_init(&q->not_full, NULL);
+}
+
+static int q_push(bucket_queue *q, const bucket_entry *e) {
+    pthread_mutex_lock(&q->mu);
+    while (q->size == q->cap && !stop)
+        pthread_cond_wait(&q->not_full, &q->mu);
+    if (stop) { pthread_mutex_unlock(&q->mu); return 0; }
+    q->buf[q->tail] = *e;
+    q->tail = (q->tail + 1) % q->cap; q->size++;
+    pthread_cond_signal(&q->not_empty);
+    pthread_mutex_unlock(&q->mu);
+    return 1;
+}
+
+static int q_pop(bucket_queue *q, bucket_entry *out) {
+    pthread_mutex_lock(&q->mu);
+    while (q->size == 0 && !stop)
+        pthread_cond_wait(&q->not_empty, &q->mu);
+    if (q->size == 0 && stop) { pthread_mutex_unlock(&q->mu); return 0; }
+    *out = q->buf[q->head];
+    q->head = (q->head + 1) % q->cap; q->size--;
+    pthread_cond_signal(&q->not_full);
+    pthread_mutex_unlock(&q->mu);
+    return 1;
+}
+
+/* Spooler file ops */
+static int ensure_spool_dir(void) {
+    struct stat st;
+    if (stat(SPOOL_DIR, &st) == 0) return 0;
+    if (mkdir(SPOOL_DIR, 0755) == 0) return 0;
+    perror("mkdir spool dir");
+    return -1;
+}
+
+static void spooler_open(spooler_t *s) {
+    if (ensure_spool_dir() != 0) exit(1);
+    char tsbuf[32];
+    time_t t = time(NULL); struct tm tm; gmtime_r(&t, &tm);
+    strftime(tsbuf, sizeof tsbuf, "%Y%m%dT%H%M%SZ", &tm);
+
+    snprintf(s->path_open, sizeof s->path_open,
+             SPOOL_DIR "/host=%s.ts=%s.seq=%06llu.ndjson.open",
+             s->hostname, tsbuf, (unsigned long long)(s->seq++));
+    /* strip ".open" for final */
+    snprintf(s->path_ready, sizeof s->path_ready, "%.*s",
+             (int)(strlen(s->path_open) - 5), s->path_open);
+
+    s->fp = fopen(s->path_open, "ab");
+    if (!s->fp) { perror("fopen spool"); exit(1); }
+
+    s->bytes = 0;
+    s->docs  = 0;
+    s->opened_ms = now_ms();
+}
+
+static void spooler_close(spooler_t *s) {
+    if (!s->fp) return;
+    fflush(s->fp);
+    fsync(fileno(s->fp));
+    if (fclose(s->fp) != 0) perror("fclose spool");
+    s->fp = NULL;
+    if (rename(s->path_open, s->path_ready) != 0) {
+        perror("rename spool segment");
+    }
+}
+
+static void spooler_rotate_if_needed(spooler_t *s) {
+    uint64_t age = now_ms() - s->opened_ms;
+    if (s->bytes >= SEG_MAX_BYTES || s->docs >= SEG_MAX_DOCS || age >= SEG_MAX_AGE_MS) {
+        spooler_close(s);
+        spooler_open(s);
+    }
+}
+
+/* Helper: write an array of int_metric_sample as compact JSON */
+static size_t write_int_samples_json(FILE *fp, const int_metric_sample *arr, uint32_t count) {
+    size_t n = 0;
+    if (count > MAX_INT_NODES) count = MAX_INT_NODES;
+    n += fputc('[', fp) != EOF ? 1 : 0;
+    for (uint32_t i = 0; i < count; i++) {
+        if (i) n += fputc(',', fp) != EOF ? 1 : 0;
+        n += fprintf(fp,
+            "{\"node_id\":%u,\"hop_latency\":%u,\"queue_occupancy\":%u,\"egress_interface_tx\":%u}",
+            arr[i].node_id,
+            arr[i].hop_latency,
+            arr[i].queue_occupancy,
+            arr[i].egress_interface_tx
+        );
+    }
+    n += fputc(']', fp) != EOF ? 1 : 0;
+    return n;
+}
+
+/* Write ONE NDJSON doc per call (no Bulk action line). */
+static void write_doc_ndjson(FILE *fp, const bucket_entry *e,
+                             const char *hostname, size_t *bytes_accum, size_t *docs_accum) {
+    char ts_now[48]; now_iso8601(ts_now, sizeof ts_now);
+    uint32_t n = e->int_metric_info_value.node_count;
+    if (n > MAX_INT_NODES) n = MAX_INT_NODES;
+
+    size_t wrote = 0;
+    wrote += fprintf(fp,
+        "{"
+          "\"@timestamp\":\"%s\","
+          "\"host\":{\"name\":\"%s\"},"
+          "\"flow\":{"
+            "\"id\":\"%08x-%08x-%08x-%08x\","
+            "\"key\":[%u,%u,%u,%u]"
+          "},"
+          "\"network\":{\"packets\":%u},"
+          "\"int_ts_raw\":%llu,"
+          "\"int\":{"
+            "\"node_count\":%u,"
+            "\"latest\":",
+        ts_now, hostname,
+        e->key[0], e->key[1], e->key[2], e->key[3],
+        e->key[0], e->key[1], e->key[2], e->key[3],
+        e->packet_count,
+        (unsigned long long)e->last_update_timestamp,
+        n
+    );
+
+    wrote += write_int_samples_json(fp, e->int_metric_info_value.latest,  n);
+    wrote += fprintf(fp, ",\"average\":");
+    wrote += write_int_samples_json(fp, e->int_metric_info_value.average, n);
+    wrote += fprintf(fp, "}}\n");
+
+    fflush(fp);
+    *bytes_accum += wrote;
+    *docs_accum  += 1;
+}
+
+/* Spooler thread: drain until q_pop returns 0 (i.e., stop && empty) */
+static void* spooler_thread(void *arg) {
+    (void)arg;
+    spooler_open(&g_spooler);
+
+    bucket_entry e;
+    for (;;) {
+        if (!q_pop(&g_q, &e)) break;  // returns 0 only if stop && queue empty
+        write_doc_ndjson(g_spooler.fp, &e, g_spooler.hostname, &g_spooler.bytes, &g_spooler.docs);
+        spooler_rotate_if_needed(&g_spooler);
+    }
+
+    spooler_close(&g_spooler);
+    return NULL;
+}
+
+/* ---------------- Public API ---------------- */
+void spooler_init(void) {
+    q_init(&g_q, QUEUE_CAPACITY);
+    if (gethostname(g_spooler.hostname, sizeof g_spooler.hostname) != 0)
+        strncpy(g_spooler.hostname, "unknown", sizeof g_spooler.hostname);
+    g_spooler.hostname[sizeof g_spooler.hostname - 1] = '\0';
+    g_spooler.seq = 0;
+}
+
+void spooler_start(void) {
+    if (pthread_create(&g_thread, NULL, spooler_thread, NULL) != 0) {
+        perror("pthread_create spooler");
+        exit(1);
+    }
+}
+
+void spooler_stop(void) {
+    // Wake any waiters so the thread can observe 'stop' and drain/exit.
+    pthread_mutex_lock(&g_q.mu);
+    pthread_cond_broadcast(&g_q.not_empty);
+    pthread_cond_broadcast(&g_q.not_full);
+    pthread_mutex_unlock(&g_q.mu);
+    pthread_join(g_thread, NULL);
+}
+
+int spooler_enqueue(const bucket_entry *e) {
+    return q_push(&g_q, e);
+}

--- a/host/spooler.h
+++ b/host/spooler.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <stddef.h>
+#include <stdint.h>
+#include "ring_defs.h"
+
+/**
+ * The spooler is responsible for:
+ *  - Draining bucket_entry items from a bounded queue.
+ *  - Writing them as plain NDJSON in Elasticsearch Bulk format
+ *    (action line + document line).
+ *  - Rotating files when they reach a max size, doc count,
+ *    or age threshold.
+ *  - Renaming files from .open → .ready for durability and
+ *    safe handoff to Filebeat/Logstash.
+ */
+
+#define QUEUE_CAPACITY (1u << 20) /* ~1M entries */
+
+void spooler_init(void);
+void spooler_start(void);
+void spooler_stop(void);
+
+/* Producer side API: enqueue a new entry */
+int spooler_enqueue(const bucket_entry *e);


### PR DESCRIPTION
## ¿Qué escribe el *spooler*?

El *spooler* consume entradas (`bucket_entry`) desde una cola acotada y las **vuelca como líneas NDJSON** (un documento JSON por línea) en segmentos de archivo. Cada entrada representa un “snapshot” de métricas INT para un flujo.

- **Directorio de salida:** `/var/spool/int/`
- **Escritura segura:** primero escribe en `*.ndjson.open` y, al rotar/cerrar el segmento, realiza un `rename()` atómico a `*.ndjson`. Filebeat debe leer solo los archivos `*.ndjson` (no los `*.open`).
- **Apagado:** al finalizar, el spooler drena la cola y cierra/renombra el último segmento.

### Esquema de nombres de archivo
Mientras se escribe:
```
/var/spool/int/host=<HOST>.ts=<UTC_ISO_Z>.seq=<NNNNNN>.ndjson.open
```
Cuando el segmento queda listo:
```
/var/spool/int/host=<HOST>.ts=<UTC_ISO_Z>.seq=<NNNNNN>.ndjson
```

> **Nota:** Filebeat debe apuntar solo a `*.ndjson` (no a `*.open`).

---

## Formato del documento (NDJSON)

Cada **línea** del archivo es **un JSON completo** con estos campos:

- `@timestamp` (ISO-8601, UTC): instante de generación en el host.
- `host.name`: nombre del host que escribe.
- `flow.id`: identificador derivado de la clave del flujo (4 × `u32`, renderizado en hex).
- `flow.key[]`: la clave cruda del flujo como arreglo de 4 enteros.
- `network.packets`: contador de paquetes observado.
- `int_ts_raw`: timestamp crudo del NIC (nanosegundos).
- `int.node_count`: cantidad de nodos INT observados.
- `int.latest[]`: arreglo de muestras por nodo `{node_id, hop_latency, queue_occupancy, egress_interface_tx}` (últimas).
- `int.average[]`: mismo esquema, pero promedios.

### Ejemplo de línea NDJSON
```json
{
  "@timestamp": "2025-09-24T18:20:00.123Z",
  "host": { "name": "cluster-ml-1" },
  "flow": {
    "id": "1a2b3c4d-5e6f7a8b-9c0d1e2f-33445566",
    "key": [439041101, 1584364171, 26214, 858993459]
  },
  "network": { "packets": 42 },
  "int_ts_raw": 1695579600123456789,
  "int": {
    "node_count": 3,
    "latest": [
      {"node_id":1,"hop_latency":120,"queue_occupancy":7,"egress_interface_tx":3},
      {"node_id":7,"hop_latency":90,"queue_occupancy":4,"egress_interface_tx":1},
      {"node_id":9,"hop_latency":110,"queue_occupancy":5,"egress_interface_tx":2}
    ],
    "average": [
      {"node_id":1,"hop_latency":130,"queue_occupancy":8,"egress_interface_tx":3},
      {"node_id":7,"hop_latency":95,"queue_occupancy":5,"egress_interface_tx":1},
      {"node_id":9,"hop_latency":105,"queue_occupancy":6,"egress_interface_tx":2}
    ]
  }
}
```
