### PR TITLE
Convert `int_ts_raw` to string to avoid Elasticsearch long overflow

### DIFF
--- a/bin/setup_logstash
+++ b/bin/setup_logstash
@@ -111,6 +111,10 @@ filter {
 
           event.set("[flow][proto]", keys[3])
         end
+
+        # --- Convert int_ts_raw to string to avoid Elasticsearch long overflow ---
+        raw_ts = event.get("int_ts_raw")
+        event.set("int_ts_raw", raw_ts.to_s) if raw_ts
       '
     }
 


### PR DESCRIPTION
The index template was updated  in elasticsearch UI
```
PUT _index_template/int-metrics
{
  "index_patterns": ["int-metrics-*"],
  "template": {
    "mappings": {
      "properties": {
        "int_ts_raw": { "type": "keyword" }
      }
    }
  }
 ```