### PR TITLE
Fix protocol for NPT=2

### DIFF
--- a/sink/main.c
+++ b/sink/main.c
@@ -7,6 +7,7 @@
 static __inline int _get_hash_key(EXTRACTED_HEADERS_T *headers, uint32_t hash_key[4]) {
   uint32_t src_port;
   uint32_t dst_port;
+  uint32_t proto;
 
   PIF_PLUGIN_ipv4_T *ipv4 = pif_plugin_hdr_get_ipv4(headers);
   PIF_PLUGIN_udp_T *udp = pif_plugin_hdr_get_udp(headers);
@@ -19,9 +20,11 @@ static __inline int _get_hash_key(EXTRACTED_HEADERS_T *headers, uint32_t hash_ke
 
     src_port = udp->src_port;
     dst_port = (first_word << 8) | second_word;
+    proto = ipv4->protocol;
   } else if (int_shim->npt == 2 && int_shim->reserved == IP_PROTO_TCP){
     src_port = tcp->src_port;
     dst_port = tcp->dst_port;
+    proto = int_shim->reserved;
   } else {
     return -1;
   }
@@ -29,7 +32,7 @@ static __inline int _get_hash_key(EXTRACTED_HEADERS_T *headers, uint32_t hash_ke
   hash_key[0] = ipv4->src_addr;
   hash_key[1] = ipv4->dst_addr;
   hash_key[2] = (src_port << 16) | dst_port;
-  hash_key[3] = ipv4->protocol;
+  hash_key[3] = proto;
 
   return 0;
 }


### PR DESCRIPTION
Según spec:
- NPT (Next Protocol Type, 2b): This field is meaningful only when the UDP destination
port number (INT_TBD) is used to indicate the existence of INT. In the other cases, this
field must be zero. When UDP destination port is INT_TBD, this field may have one of the
two values: 
  - one (1): indicates that the original UDP payload follows the INT stack, and the last
two bytes of the shim header carry the original UDP destination port.
  - two (2): indicates that another (the original) L4 header follows the INT stack, and the
last byte of the shim header carries the IP protocol value for the L4 layer.

- UDP port, IP proto, or DSCP (16b): The contents of this field differ depending on the
value of NPT.
  - NPT=0: The first byte and the last two bits of this 16b field are reserved, set to zero
upon transmission and ignored upon reception. The first 6 bits of the second byte may
optionally carry the original DSCP value.
  - NPT=1: The original UDP destination port value.
  - NPT=2: The first byte is reserved, set to zero upon transmission and ignored upon
reception. The second byte carries the original IP protocol value.